### PR TITLE
feature/alllog_sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ jackets/*
 *.png
 log/*
 params_secret.py
+
+# PyClipse project files
+.project
+.pydevproject

--- a/alllog_sync.py
+++ b/alllog_sync.py
@@ -44,20 +44,20 @@ def isSongInLog(songLog, songToSearch):
             diferenceInSeconds = abs((songSSTime - songLogTime).total_seconds())
             
             if songLogDate == songSSDate and diferenceInSeconds < 120:
-                #print(f'Song {songFromScreenshot.title} already exists on file')
+                #print(f'Song {songToSearch.title} already exists on file')
                 songFound = True
                 break
             else: 
-                #print(f'Song \'{songFromScreenshot.title}\' already exists on file but with different date: {songFromLog.date} in log vs {songFromScreenshot.date} in screenshot ({diferenceInSeconds}s difference)')
+                #print(f'Song \'{songToSearch.title}\' already exists on file but with different date: {songFromLog.date} in log vs {songToSearch.date} in screenshot ({diferenceInSeconds}s difference)')
                 songExistOnDate = True
             
 
     if not songFound and not songExistOnDate:
-        print(f'Song \'{songFromScreenshot.title}\' is new!')
+        print(f'Song \'{songToSearch.title}\' is new!')
         return False
     elif not songFound and songExistOnDate : 
-        print(f'Song \'{songFromScreenshot.title}\' already exists but with another date. Adding new date.')
-        return False
+        #print(f'Song \'{songToSearch.title}\' already exists but with another date.')
+        return True
 
     return True
 

--- a/alllog_sync.py
+++ b/alllog_sync.py
@@ -1,0 +1,134 @@
+import pickle
+import os
+from os import path
+from PIL import Image
+from datetime import datetime 
+from sdvxh_classes import OnePlayData
+from gen_summary import GenSummary
+
+
+def load():
+    ret = None
+    with open('D:/Tools/SoundVoltex/sdvx_helper/alllog.pkl', 'rb') as f:
+        ret = pickle.load(f)
+    return ret
+
+
+def save(dat:dict):
+    with open('D:/Tools/SoundVoltex/sdvx_helper/alllog.pkl', 'wb') as f:
+        pickle.dump(dat, f)
+
+        
+def isSongInLog(songLog, songToSearch):
+    
+    songFound = False
+    songExistOnDate = False
+    for songFromLog in songLog:
+        if songFromLog.title == songFromScreenshot.title and songFromLog.date == songFromScreenshot.date:
+#            print(f'Song {songFromScreenshot.title} already exists on file')
+            songFound = True
+            break
+        elif songFromLog.title == songFromScreenshot.title:
+            songLogDate = songFromLog.date.split('_')[0]
+            songLogTime = datetime.strptime(songFromLog.date.split('_')[1], '%H%M%S')
+            
+            if not "_" in songFromScreenshot.date: 
+                print(f'Mallformed song data: {songFromScreenshot.disp()}')
+            
+            songSSDate = songFromScreenshot.date.split('_')[0]
+            songSSTime = datetime.strptime(songFromScreenshot.date.split('_')[1], '%H%M%S')
+            
+            diferenceInSeconds = abs((songSSTime - songLogTime).total_seconds())
+            
+            if songLogDate == songSSDate and diferenceInSeconds < 120:
+                #print(f'Song {songFromScreenshot.title} already exists on file')
+                songFound = True
+                break
+            else: 
+                #print(f'Song \'{songFromScreenshot.title}\' already exists on file but with different date: {songFromLog.date} in log vs {songFromScreenshot.date} in screenshot ({diferenceInSeconds}s difference)')
+                songExistOnDate = True
+            
+
+    if not songFound and not songExistOnDate:
+        print(f'Song \'{songFromScreenshot.title}\' is new!')
+        return False
+    elif not songFound and songExistOnDate : 
+        print(f'Song \'{songFromScreenshot.title}\' already exists but with another date. Adding new date.')
+        return False
+
+    return True
+
+# TODO: Find a way to extract the data from a result screenshot without data in the filename
+def parse_unparsed_results_screen (resultsFilename):
+    img = Image.open(os.path.abspath(f'{rootFolder}/{playScreenshotFileName}'))
+    parts = genSummary.cut_result_parts(img)
+    genSummary.ocr()
+    dif = genSummary.difficulty
+
+if __name__ == '__main__':
+    songLog = load()
+    
+    updatedSongs = 0
+    
+    # TODO: Argument
+    rootFolder = 'D:/Tools/SoundVoltex/results'
+
+    # When running manually, call in the settings yourself to be able to run from the IDE
+    start = datetime(year=2023, month=10, day=15, hour=0)
+    genSummary = GenSummary(start, rootFolder.join('/sync'), 'true', 255, 2)
+
+    for playScreenshotFileName in os.listdir(rootFolder):
+        # We ignore files which are a summany and are not png
+        if playScreenshotFileName.find('summary') > 0 :
+            continue
+        
+        if playScreenshotFileName.find('png') < 0 :
+            continue
+
+        nameSplits = playScreenshotFileName.split("_")
+        
+        songTitle = ''
+        dif = ''
+        lamp = ''
+        score = ''
+        playDate = ''
+        
+        # Go through all the filename parts to extract the song data. The ocr_reporter must be used 1st to put that inforation
+        # in the filename of the results screenshot
+        for split in nameSplits:
+            if split == 'sdvx':
+                continue
+            
+            # Files that have no information about them on the filename should try to get their information
+            # From the results screenshot
+            if split.isnumeric() and songTitle == '': 
+                #parse_unparsed_results_screen(playScreenshotFileName)
+                break
+            
+            if dif == '' and split != 'NOV' and split != 'ADV' and split != 'EXH':
+                 songTitle += split + ' '
+            elif dif == '': 
+                dif = split
+            elif dif != '' and lamp == '':
+                lamp = split                
+            elif lamp != ''  and score == '':
+                score = split
+            elif score != '':
+                playDate += split + '_'
+        
+        # print(f'Read from file: {songTitle} - {dif} - {lamp} - {score} - {playDate}')
+
+        if songTitle != '':
+            
+            img = Image.open(os.path.abspath(f'{rootFolder}/{playScreenshotFileName}'))
+            scoreFromImage = genSummary.get_score(img)                
+            
+            songFromScreenshot = OnePlayData(songTitle.removesuffix(' '), scoreFromImage[0], scoreFromImage[1], lamp, dif.lower(), playDate.removesuffix('.png_'))
+
+            # If the song is not in the long, with a tolerance of 120 seconds, add it to the log                
+            if not isSongInLog(songLog, songFromScreenshot):
+                songLog.append(songFromScreenshot)
+                updatedSongs += 1
+        
+    print(f'Update song log with {updatedSongs} songs')
+    save(songLog)

--- a/alllog_sync.py
+++ b/alllog_sync.py
@@ -47,6 +47,7 @@ def isSongInLog(songLog, songToSearch):
                 return True                
             
             songSSDate = songToSearch.date.split('_')[0]
+            #print(f'Searching for {songToSearch.title}')
             songSSTime = datetime.strptime(songToSearch.date.split('_')[1], '%H%M%S')
             
             diferenceInSeconds = abs((songSSTime - songLogTime).total_seconds())
@@ -141,12 +142,17 @@ def main(songLogFolder, resultsFolder):
          
         # Set the rest of the data based on offset of the last chunk of the title       
         dif = nameSplits[lastIndexOfName+1]
+        
+        # If the chunk after the difficulty is 'class' we know it's a screenshot of the Skill Analyser mode and we skip that chunk
+        if nameSplits[lastIndexOfName+2] == 'class' :
+            lastIndexOfName+=1
+            
         lamp = nameSplits[lastIndexOfName+2]
         
         # It can happen that the score is empty and we have a file of type
         # sdvx_プナイプナイたいそう_NOV_failed__20250111_173755
         # In the case, consider the score 0 otherwise things might break later 
-        # if the playDate chunks are not assigbned correctly
+        # if the playDate chunks are not assigned correctly
         if nameSplits[lastIndexOfName+3] == '' :
             score = 0
         else :

--- a/gen_summary.py
+++ b/gen_summary.py
@@ -28,17 +28,36 @@ except Exception:
     SWVER = "v?.?.?"
 
 class GenSummary:
-    def __init__(self, now):
+    
+    def __init__(self, now, autosave_dir=None, ignore_rankD=None, logpic_bg_alpha=None, log_maxnum=None):
         self.start = now
         self.result_parts = False
         self.difficulty = False
         self.load_settings()
         self.load_hashes()
-        self.savedir = self.settings['autosave_dir']
-        self.ignore_rankD = self.settings['ignore_rankD']
-        self.alpha = self.settings['logpic_bg_alpha']
-        self.max_num = self.params['log_maxnum']
+        
+        if autosave_dir : 
+            self.savedir = autosave_dir
+        else :
+            self.savedir = self.settings['autosave_dir']
+            
+        if ignore_rankD : 
+            self.ignore_rankD = ignore_rankD
+        else :
+            self.ignore_rankD = self.settings['ignore_rankD']
+            
+        if logpic_bg_alpha:
+            self.alpha = logpic_bg_alpha
+        else :
+            self.alpha = self.settings['logpic_bg_alpha']
+            
+        if log_maxnum :
+            self.max_num = log_maxnum
+        else :
+            self.max_num = self.params['log_maxnum']
+            
         print(now, self.savedir)
+    
 
     def load_settings(self):
         try:


### PR DESCRIPTION
Added a python script and functionality that reads the result screenshots taken from svdx_helper and adds them to the play log if some of them are missing so that they can be seen by the `score_manager.exe`.

In order for this to work, the file names must have been completed by the `ocr_reporter.exe` so that they look like `sdvx_Monkey_Business_-Satire_mix-_NOV_clear_985_20241201_140552.png`

The script accepts 2 arguments
```
--songLog The directory containing the alllog file
--results The directory containing the result screenshots
```
Must be run from the command line as it has no interface.
Usage:
`python alllog_sync.py --songLog D:/Tools/SoundVoltex/sdvx_helper --results D:/Tools/SoundVoltex/results`

