### PR TITLE
 feat: Add new Configuration option to let user determine if Direct Capture method should use all monitors, or only the primary monitor, to frame capture

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -26,6 +26,8 @@ class Config:
         """直接取得対象のプロセス名"""
         self.direct_capture_title: str = 'SOUND VOLTEX EXCEED GEAR'
         """直接取得対象のウィンドウタイトル"""
+        self.direct_capture_all_monitors: bool = False
+        """Whether to capture all monitors. Only applies when capture_method is 'direct_window'. Enabling this can cause frame lag in sv6c.exe, if the monitors being captured use mixed refresh rates."""
         self.obs_scene_collection: str = ''
         """起動時に切り替えるシーンコレクション（空=切り替えなし）"""
         self.obs_control_enabled: bool = False

--- a/src/config_dialog.py
+++ b/src/config_dialog.py
@@ -519,8 +519,8 @@ class ConfigDialog(QDialog):
         method_group.setLayout(method_layout)
 
         self.capture_method_group = QButtonGroup()
-        self.capture_method_obs_radio = QRadioButton(self.ui.capture.method_obs_websocket)
         self.capture_method_direct_radio = QRadioButton(self.ui.capture.method_direct_window)
+        self.capture_method_obs_radio = QRadioButton(self.ui.capture.method_obs_websocket)
         self.capture_method_group.addButton(self.capture_method_direct_radio, 0)
         self.capture_method_group.addButton(self.capture_method_obs_radio, 1)
 
@@ -529,6 +529,9 @@ class ConfigDialog(QDialog):
         method_radio_row.addWidget(self.capture_method_obs_radio)
         method_radio_row.addStretch()
         method_layout.addRow(self.ui.capture.method_label, method_radio_row)
+
+        self.direct_capture_all_monitors_check = QCheckBox(self.ui.capture.direct_capture_all_monitors)
+        method_layout.addRow(self.direct_capture_all_monitors_check)
 
         layout.addWidget(method_group)
 
@@ -1317,6 +1320,8 @@ class ConfigDialog(QDialog):
         else:
             self.capture_method_obs_radio.setChecked(True)
 
+        self.direct_capture_all_monitors_check.setChecked(self.config.direct_capture_all_monitors)
+
         orient_map = {None: 0, 'top_up': 1, 'top_right': 2, 'top_left': 3}
         btn_id = orient_map.get(self.config.screen_orientation_override, 0)
         btn = self.orientation_group.button(btn_id)
@@ -1373,6 +1378,8 @@ class ConfigDialog(QDialog):
             if self.capture_method_group.checkedId() == 0
             else 'obs_websocket'
         )
+
+        self.config.direct_capture_all_monitors = self.direct_capture_all_monitors_check.isChecked()
 
         orient_map = {0: None, 1: 'top_up', 2: 'top_right', 3: 'top_left'}
         self.config.screen_orientation_override = orient_map.get(

--- a/src/direct_window_capture.py
+++ b/src/direct_window_capture.py
@@ -183,7 +183,7 @@ class DirectWindowCapture:
         bbox = self._client_screen_bbox(hwnd)
         if bbox is not None:
             try:
-                return ImageGrab.grab(bbox=bbox, all_screens=True).convert("RGB")
+                return ImageGrab.grab(bbox=bbox, all_screens=self.config.direct_capture_all_monitors).convert("RGB")
             except Exception as e:
                 self._log_error("ImageGrabで直接キャプチャできませんでした: %s", e)
 

--- a/src/ui_en.py
+++ b/src/ui_en.py
@@ -94,6 +94,7 @@ class UIText:
         method_label = 'Method:'
         method_obs_websocket = 'OBS WebSocket'
         method_direct_window = 'Direct capture'
+        direct_capture_all_monitors = '(Applies to direct capture only) Capture all monitors'
         orientation_group = 'Screen Orientation'
         orientation_auto = 'Auto-detect'
         orientation_top_up = 'Top up (top_up)'

--- a/src/ui_jp.py
+++ b/src/ui_jp.py
@@ -94,6 +94,7 @@ class UIText:
         method_label = '方式:'
         method_obs_websocket = 'OBS WebSocket'
         method_direct_window = '直接取得'
+        direct_capture_all_monitors = '(ダイレクトキャプチャのみ) すべてのモニターをキャプチャする'
         orientation_group = '画面向き'
         orientation_auto = '自動検出'
         orientation_top_up = '上向き (top_up)'


### PR DESCRIPTION
### Investigation

Hi kata,

I took a look into the issue I reached out to you about previously.

After getting the project building, reading through the direct window capture code and playing with it, I noticed that the laggy frame issue on SDVX itself went away if I stubbed in a `bbox = None` [here](https://github.com/joseph-galindo/sdvx_helper/blob/6c882974bcb15afc405c2ef9433b9abce7e29dac/src/direct_window_capture.py#L183), essentially skipping the call to `return ImageGrab.grab(bbox=bbox, all_screens=True).convert("RGB")`. In other words, I was only getting lag with the direct capture method when the ImageGrab.grab() call happened.

From there, I took a closer look at just the [ImageGrab.Grab API](https://pillow.readthedocs.io/en/stable/reference/ImageGrab.html#PIL.ImageGrab.grab). I noticed that if I set `all_screens=False`, frame timing/performance in sv6c.exe was noticeably better.

For more context, the PC I play SDVX on and use sdvx_helper, has two monitors. One is the primary vertical monitor running sdvx (1440x2560 vertical, 144hz refresh rate), and the second monitor is used for other purposes (1920x1080 horizontal, 120hz refresh rate). Note that the refresh rates are different (144hz and 120hz). I couldn't find a specific issue at the [Pillow repo](https://github.com/python-pillow/Pillow) discussing this problem, but I suspect the root problem is close to this summary from Gemini:

> Using ImageGrab.grab(all_screens=True) from the [ImageGrab module - Pillow](https://pillow.readthedocs.io/en/stable/reference/ImageGrab.html) on a system with mixed refresh rate monitors captures a single snapshot across all displays. However, it does not sync or lock to individual refresh rates, **which can result in frame tearing or mixed-timing artifacts if monitors run at different speeds (e.g., 60Hz and 144Hz) during continuous capture**.

I also considered skipping the ImageGrab.grab call entirely, and only using the `QGuiApplication` `qImage` fallback, but I was noticing separate issues where that capture seemed to only be returning a white screen, not actually capturing the gameplay frame (this can probably be spun into a separate issue/PR on its own).

### Solution

To work around this issue with `all_screens=True` hampering performance on systems that have mixed refresh rate monitors, I added a new config option to let the user determine if the Direct Capture method should capture ALL monitors on the system (the behavior with `all_screens=True`), or only the primary monitor (the behavior with `all_screens=False`).

The new config UI looks like this:

JP
<img width="752" height="632" alt="image" src="https://github.com/user-attachments/assets/9602a386-46e7-426d-a385-0f6a8942759d" />


ENG
<img width="752" height="632" alt="image" src="https://github.com/user-attachments/assets/27959d87-c734-4d6f-846a-71d9c371acac" />

- Turning the checkbox to ON tells the ImageGrab.Grab call to use `all_screens=True` (keeping the same behavior as sdvx_helper v2.0.6)
- Turning the checkbox to OFF tells the ImageGrab call to use `all_screens=False` (new behavior, which should improve performance on systems using multiple monitors with mixed refresh rates)
- This PR defaults the checkbox to being OFF, so merging this PR would introduce a default behavior change compared to v2.0.6. I could change the PR to default the checkbox to being ON if that would be preferred.
